### PR TITLE
Add version and extuable name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@
 
 
 PROJECT(Nonlocalheatequation)
+set (VERSION_MAJOR 0)
+set (VERSION_MINOR 1)
+set (VERSION_UPDATE 0)
+
+configure_file (
+  "${PROJECT_SOURCE_DIR}/Config.h.in"
+  "${PROJECT_SOURCE_DIR}/include/Config.h"
+  )
 
 cmake_minimum_required(VERSION 3.10)
 

--- a/Config.h.in
+++ b/Config.h.in
@@ -1,0 +1,15 @@
+// Copyright (c) 2020    Patrick Diehl
+//
+// Distributed under the GNU GENERAL PUBLIC LICENSE, Version 3.0.
+// (See accompanying file LICENSE.txt)
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include<cstddef>
+
+size_t const MAJOR_VERSION = @VERSION_MAJOR@;
+size_t const MINOR_VERSION = @VERSION_MINOR@;
+size_t const UPDATE_VERSION = @VERSION_UPDATE@;
+
+#endif

--- a/src/1d_nonlocal_serial.cpp
+++ b/src/1d_nonlocal_serial.cpp
@@ -22,6 +22,7 @@
 #include "../include/point.h"
 #include "../include/print_time_results.hpp"
 #include "../include/writer.h"
+#include "../include/Config.h"
 
 bool header = 0;
 double k = 1;    // heat transfer coefficient
@@ -310,6 +311,10 @@ int hpx_main(hpx::program_options::variables_map& vm) {
 }
 
 int main(int argc, char* argv[]) {
+  std::cout << argv[0] << " ("
+    << MAJOR_VERSION << "."
+    << MINOR_VERSION << "."
+    << UPDATE_VERSION << ")" << std::endl;
   namespace po = hpx::program_options;
 
   po::options_description desc_commandline;

--- a/src/2d_nonlocal_async.cpp
+++ b/src/2d_nonlocal_async.cpp
@@ -30,6 +30,7 @@
 #include "../include/point.h"
 #include "../include/print_time_results.hpp"
 #include "../include/writer.h"
+#include "../include/Config.h"
 
 bool header = 1;
 double k = 1;       // heat transfer coefficient
@@ -542,6 +543,10 @@ int hpx_main(hpx::program_options::variables_map &vm) {
 }
 
 int main(int argc, char *argv[]) {
+  std::cout << argv[0] << " ("
+    << MAJOR_VERSION << "."
+    << MINOR_VERSION << "."
+    << UPDATE_VERSION << ")" << std::endl;
   namespace po = hpx::program_options;
 
   po::options_description desc_commandline;

--- a/src/2d_nonlocal_distributed.cpp
+++ b/src/2d_nonlocal_distributed.cpp
@@ -33,6 +33,7 @@
 #include "../include/point.h"
 #include "../include/print_time_results.hpp"
 #include "../include/writer.h"
+#include "../include/Config.h"
 
 bool header = 1;
 double k = 1;       // heat transfer coefficient
@@ -804,6 +805,10 @@ int hpx_main(hpx::program_options::variables_map& vm) {
 }
 
 int main(int argc, char* argv[]) {
+  std::cout << argv[0] << " ("
+    << MAJOR_VERSION << "."
+    << MINOR_VERSION << "."
+    << UPDATE_VERSION << ")" << std::endl;
   namespace po = hpx::program_options;
 
   po::options_description desc_commandline;

--- a/src/2d_nonlocal_serial.cpp
+++ b/src/2d_nonlocal_serial.cpp
@@ -21,6 +21,7 @@
 #include "../include/point.h"
 #include "../include/print_time_results.hpp"
 #include "../include/writer.h"
+#include "../include/Config.h"
 
 bool header = 1;
 double k = 1;    // heat transfer coefficient
@@ -379,6 +380,10 @@ int hpx_main(hpx::program_options::variables_map& vm) {
 }
 
 int main(int argc, char* argv[]) {
+  std::cout << argv[0] << " ("
+    << MAJOR_VERSION << "."
+    << MINOR_VERSION << "."
+    << UPDATE_VERSION << ")" << std::endl;
   namespace po = hpx::program_options;
 
   po::options_description desc_commandline;


### PR DESCRIPTION
We print the name of the executable and the version to have better documentation for the benchmarks
```
diehlpk@localhost ~/g/nonlocalheatequation (documentation)> ./build/1d_nonlocal_serial 
./build/1d_nonlocal_serial (0.1.0)

```